### PR TITLE
add context & waitgroup

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
@@ -16,6 +17,27 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
+
+type Option func(*Options)
+
+type Options struct {
+	SkipDefaultDoneSignals bool
+	WaitGroup              *sync.WaitGroup
+}
+
+// SkipDefaultDoneSignals skips the default done signals (os.Interrupt, syscall.SIGINT, syscall.SIGTERM) to shutdown the HTTP server.
+func SkipDefaultDoneSignals() Option {
+	return func(o *Options) {
+		o.SkipDefaultDoneSignals = true
+	}
+}
+
+// WaitGroup sets the wait group to use for the HTTP server.
+func WithWaitGroup(wg *sync.WaitGroup) Option {
+	return func(o *Options) {
+		o.WaitGroup = wg
+	}
+}
 
 // DefaultCommandFn is a CommandFn that returns the first part of s.Command().
 func DefaultCommandFn(s ssh.Session) string {
@@ -37,9 +59,32 @@ func Middleware(address, app string) wish.Middleware {
 // MiddlewareWithCommand() starts a HTTP server on the given address, serving
 // the metrics from the default registerer to /metrics, using the given
 // CommandFn to extract the `command` label value.
-func MiddlewareWithCommand(address, app string, fn CommandFn) wish.Middleware {
+func MiddlewareWithCommand(address, app string, fn CommandFn, opts ...Option) wish.Middleware {
+	return MiddlewareWithContextSignalCommand(context.Background(), nil, address, app, fn, opts...)
+}
+
+// MiddlewareWithContext starts a HTTP server on the given address, serving the metrics from the default registerer to /metrics.
+// It handles provided context to gracefully shutdown the server.
+func MiddlewareWithContext(context context.Context, address, app string, opts ...Option) wish.Middleware {
+	return MiddlewareWithContextSignal(context, nil, address, app, opts...)
+}
+
+// MiddlewareWithContextSignal starts a HTTP server on the given address, serving the metrics from the default registerer to /metrics.
+// It handles provided context and exit signals to gracefully shutdown the server.
+func MiddlewareWithContextSignal(context context.Context, done chan os.Signal, address, app string, opts ...Option) wish.Middleware {
+	return MiddlewareWithContextSignalCommand(context, done, address, app, DefaultCommandFn, opts...)
+}
+
+// MiddlewareWithContextSignalCommand starts a HTTP server on the given address, serving the metrics from the default registerer to /metrics.
+// It handles provided context and exit signals to gracefully shutdown the server.
+// It uses the given CommandFn to extract the `command` label value.
+func MiddlewareWithContextSignalCommand(context context.Context, done chan os.Signal, address, app string, fn CommandFn, opts ...Option) wish.Middleware {
+	var o Options
+	for _, opt := range opts {
+		opt(&o)
+	}
 	go func() {
-		Listen(address)
+		ListenWithContextSignal(context, done, address, opts...)
 	}()
 	return MiddlewareRegistry(
 		prometheus.DefaultRegisterer,
@@ -86,14 +131,34 @@ func MiddlewareRegistry(registry prometheus.Registerer, constLabels prometheus.L
 
 // Listen starts a HTTP server on the given address, serving the metrics from the default registerer to /metrics.
 // It handles exit signals to gracefully shutdown the server.
-func Listen(address string) {
+func Listen(address string, opts ...Option) {
+	ListenWithContextSignal(context.Background(), nil, address, opts...)
+}
+
+// DefaultDoneSignals are the signals that will trigger the shutdown of the HTTP server.
+var DefaultDoneSignals = []os.Signal{os.Interrupt, syscall.SIGINT, syscall.SIGTERM}
+
+// ListenWithContextSignal starts a HTTP server on the given address, serving the metrics from the default registerer to /metrics.
+// It handles provided context and exit signals to gracefully shutdown the server.
+func ListenWithContextSignal(ctx context.Context, done chan os.Signal, address string, opts ...Option) {
+	o := Options{}
+	for _, opt := range opts {
+		opt(&o)
+	}
+
 	srv := &http.Server{
 		Addr:    address,
 		Handler: promhttp.Handler(),
 	}
 
-	done := make(chan os.Signal, 1)
-	signal.Notify(done, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+	if o.WaitGroup != nil {
+		o.WaitGroup.Add(1)
+		log.Info("Incrementing wait group for metrics server", "address", address)
+		defer func() {
+			log.Info("Decrementing wait group for metrics server", "address", address)
+			o.WaitGroup.Done()
+		}()
+	}
 
 	go func() {
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
@@ -101,13 +166,26 @@ func Listen(address string) {
 		}
 	}()
 	log.Info("Starting metrics server", "address", "http://"+address+"/metrics")
-	
-	<-done
-	log.Info("Stopping metrics server")
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer func() { cancel() }()
 
-	if err := srv.Shutdown(ctx); err != nil {
+	if done == nil {
+		done = make(chan os.Signal, 1)
+	}
+	if !o.SkipDefaultDoneSignals {
+		signal.Notify(done, DefaultDoneSignals...)
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	select {
+	case <-ctx.Done():
+		log.Info("Context done, stopping metrics server")
+	case <-done:
+		log.Info("Received signal, stopping metrics server")
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
 		log.Fatal("Failed to shutdown metrics server", "error", err)
 	}
 	log.Info("Shutdown metrics server")


### PR DESCRIPTION
hello! i put this together for my own needs, but can clean this up or just close this pr depending on whatever works best for you.

this adds some methods to pass around context and a done signal, it adds options to skip loading the default done signals, exposes the list of done signals, and adds an option to increment and decrement a wait group.

i just named the option struct options. hope that's okay.

Also considered could just make signal and context options too