### PR TITLE
allow server input to middleware

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,8 +39,12 @@ func Middleware(address, app string) wish.Middleware {
 // the metrics from the default registerer to /metrics, using the given
 // CommandFn to extract the `command` label value.
 func MiddlewareWithCommand(address, app string, fn CommandFn) wish.Middleware {
+	return MiddlewareWithServer(NewServer(address), app, fn)
+}
+
+func MiddlewareWithServer(server *Server, app string, fn CommandFn) wish.Middleware {
 	go func() {
-		Listen(address)
+		ListenServer(server)
 	}()
 	return MiddlewareRegistry(
 		prometheus.DefaultRegisterer,
@@ -116,8 +120,12 @@ func (s *Server) Shutdown(ctx context.Context) error {
 // Listen starts a HTTP server on the given address, serving the metrics from the default registerer to /metrics.
 // It handles exit signals to gracefully shutdown the server.
 func Listen(address string) {
-	srv := NewServer(address)
+	ListenServer(NewServer(address))
+}
 
+// Listen starts a HTTP server on the given address, serving the metrics from the default registerer to /metrics.
+// It handles exit signals to gracefully shutdown the server.
+func ListenServer(srv *Server) {
 	done := make(chan os.Signal, 1)
 	signal.Notify(done, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 

--- a/main.go
+++ b/main.go
@@ -35,20 +35,20 @@ func Middleware(address, app string) wish.Middleware {
 	return MiddlewareWithCommand(address, app, DefaultCommandFn)
 }
 
-// MiddlewareWithServer() starts a HTTP server on the given address, serving
+// MiddlewareWithServer starts a HTTP server on the given address, serving
 // the metrics from the default registerer to /metrics.
 func MiddlewareWithServer(server *Server, app string) wish.Middleware {
 	return MiddlewareWithServerAndCommand(server, app, DefaultCommandFn)
 }
 
-// MiddlewareWithCommand() starts a HTTP server on the given address, serving
+// MiddlewareWithCommand starts a HTTP server on the given address, serving
 // the metrics from the default registerer to /metrics, using the given
 // CommandFn to extract the `command` label value.
 func MiddlewareWithCommand(address, app string, fn CommandFn) wish.Middleware {
 	return MiddlewareWithServerAndCommand(NewServer(address), app, fn)
 }
 
-// MiddlewareWithServerAndCommand() starts a HTTP server on the given address,
+// MiddlewareWithServerAndCommand starts a HTTP server on the given address,
 // serving the metrics from the default registerer to /metrics, using the given
 // CommandFn to extract the `command` label value.
 func MiddlewareWithServerAndCommand(server *Server, app string, fn CommandFn) wish.Middleware {
@@ -131,7 +131,7 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	return nil
 }
 
-// Listen starts a HTTP server on the given address, serving the metrics from the default registerer to /metrics.
+// Listen starts a HTTP server onthe given address, serving the metrics from the default registerer to /metrics.
 // It handles exit signals to gracefully shutdown the server.
 func Listen(address string) {
 	ListenServer(NewServer(address))

--- a/main.go
+++ b/main.go
@@ -131,7 +131,7 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	return nil
 }
 
-// Listen starts a HTTP server onthe given address, serving the metrics from the default registerer to /metrics.
+// Listen starts a HTTP server on the given address, serving the metrics from the default registerer to /metrics.
 // It handles exit signals to gracefully shutdown the server.
 func Listen(address string) {
 	ListenServer(NewServer(address))


### PR DESCRIPTION
this allows to share the middleware.

something like

```
promSrv := promwish.NewServer("localhost:8080")

s, err := wish.NewServer(
  wish.WithMiddleware(
    promwish.MiddlewarewithServer(promSrv, "my-app")
  )
)

promSrv.Shutdown(context.Background())
```

i will try to test later but this is untested atm.